### PR TITLE
197 txpower: int -> double

### DIFF
--- a/ClientServerChannelMessages.proto
+++ b/ClientServerChannelMessages.proto
@@ -114,7 +114,7 @@ message ConfigureRadioMessage {
 		required bool receiving_messages = 1; //Determines whether the radio receives messages or only routes
 		required uint32 ip_address = 2;
 		required uint32 subnet_address = 3;
-		required uint32 transmission_power = 4;
+		required double transmission_power = 4;
 		enum RadioMode {
 			SINGLE_CHANNEL = 1;
 			DUAL_CHANNEL = 2;

--- a/src/msg/MosaicConfigurationCmd.msg
+++ b/src/msg/MosaicConfigurationCmd.msg
@@ -48,7 +48,7 @@ class MosaicConfigurationCmd extends inet::Request {
     bool turnedOn0;
     inet::Ipv4Address ip0;
     inet::Ipv4Address subnet0;
-    int power0;
+    double power0;
     int numchannels0;
     int channel00;
     int	channel01;
@@ -57,7 +57,7 @@ class MosaicConfigurationCmd extends inet::Request {
     bool turnedOn1;
     inet::Ipv4Address ip1;
     inet::Ipv4Address subnet1;
-    int power1;
+    double power1;
     int	numchannels1;
     int channel10;
     int	channel11;

--- a/src/util/ClientServerChannel.h
+++ b/src/util/ClientServerChannel.h
@@ -101,7 +101,7 @@ struct CSC_radio_config{
 	bool turnedOn;
 	uint32_t ip_address;
 	uint32_t subnet;
-	int tx_power;
+	double tx_power;
 	CHANNEL_MODE channelmode;
 	RADIO_CHANNEL primary_channel;
 	RADIO_CHANNEL secondary_channel;


### PR DESCRIPTION
## Description
- ClientServerChannel protocol changed:
  - `transmission_power` type change from `uint32` to `double`
- this PR is interlocked with ns-3 federate, MOSAIC and an internal repository

## Related Issue
- internal issue 197