### PR TITLE
revised omnetpp.ini from MOSAIC's scenario Tiergarten

### DIFF
--- a/src/omnetpp.ini
+++ b/src/omnetpp.ini
@@ -66,7 +66,7 @@ Simulation.veh[*].udpApp.maxProcDelay = 0
 
 **.wlan*.mac.typename = "Ieee80211Mac"
 **.wlan*.mac.*.rateSelection.*Bitrate = 6Mbps
-**.wlan*.mac.hcf.maxQueueSize = 10
+**.wlan*.mac.*.maxQueueSize = 10
 **.wlan*.mac.**.cwMin = 15
 **.wlan*.mac.**.cwMax = 1023
 **.wlan*.mac.dcf.recoveryProcedure.shortRetryLimit = 7

--- a/src/omnetpp.ini
+++ b/src/omnetpp.ini
@@ -15,17 +15,12 @@ mosaiceventscheduler-debug = false
 mosaiceventscheduler-host = "localhost"
 mosaiceventscheduler-port = 4998
 
-# ClientServerChannel
-# -------------------
-# OMNeT++ log level names are valid, same hierarchy is used
-clientserverchannel-log-level = warn
-
 # RecordingModi
 # -------------
 record-eventlog = false
 cmdenv-express-mode = false
 cmdenv-event-banners = false
-cmdenv-log-prefix = "%t: [%M] "
+cmdenv-log-prefix = "%t s: [%M] "
 
 # random numbers
 # -------------
@@ -41,12 +36,13 @@ Simulation.wlan[*].mac.rng-0 = 2
 #
 # MOSAIC log level equivalent:     INFO      DEBUG
 #---------------------------------------------------
-**.tx.cmdenv-log-level           = info   # = info
-**.rx.cmdenv-log-level           = info   # = info
+**.tx.cmdenv-log-level           = warn   # = info
+**.rx.cmdenv-log-level           = warn   # = info
 **.proxyApp.cmdenv-log-level     = info   # = info
 Simulation.mgmt.cmdenv-log-level = info   # = info
 
 **.cmdenv-log-level              = warn   # = info   # This sets everything to level INFO
+
 
 ########### application settings ############ 
 #Simulation.rsu[*].udpApp.maxProcDelay = 1e-3
@@ -65,10 +61,10 @@ Simulation.mgmt.cmdenv-log-level = info   # = info
 #**.wlan*.bitrate = 6Mbps
 
 **.wlan*.mac.typename = "Ieee80211Mac"
-**.wlan*.mac.qosStation = true
 **.wlan*.mac.*.rateSelection.*Bitrate = 3Mbps
 **.wlan*.mac.hcf.maxQueueSize = 10
-**.wlan*.mac.hcf.edca.**.cwMin = 15
+**.wlan*.mac.cwMin = 15
+**.wlan*.mac.cwMax = 1023
 **.wlan*.mac.dcf.recoveryProcedure.shortRetryLimit = 7
 **.wlan*.mac.dcf.recoveryProcedure.longRetryLimit = 7
 
@@ -88,11 +84,3 @@ Simulation.radioMedium.mediumLimitCache.carrierFrequency = 5.9GHz
 Simulation.radioMedium.propagation.typename = "ConstantSpeedPropagation"
 Simulation.radioMedium.pathLoss.typename = "FreeSpacePathLoss"
 Simulation.radioMedium.obstacleLoss.typename = ""
-
-###########   mobility    ###################
-**.mobility.constraintAreaMinX = 0m
-**.mobility.constraintAreaMinY = 0m
-**.mobility.constraintAreaMinZ = 0m
-**.mobility.constraintAreaMaxX = 10000m
-**.mobility.constraintAreaMaxY = 10000m
-**.mobility.constraintAreaMaxZ = 0m

--- a/src/omnetpp.ini
+++ b/src/omnetpp.ini
@@ -15,12 +15,17 @@ mosaiceventscheduler-debug = false
 mosaiceventscheduler-host = "localhost"
 mosaiceventscheduler-port = 4998
 
+# ClientServerChannel
+# -------------------
+# OMNeT++ log level names are valid, same hierarchy is used
+clientserverchannel-log-level = warn
+
 # RecordingModi
 # -------------
 record-eventlog = false
 cmdenv-express-mode = false
 cmdenv-event-banners = false
-cmdenv-log-prefix = "%t s: [%M] "
+cmdenv-log-prefix = "[DEV] %t s: [%M] "
 
 # random numbers
 # -------------
@@ -45,8 +50,8 @@ Simulation.mgmt.cmdenv-log-level = info   # = info
 
 
 ########### application settings ############ 
-#Simulation.rsu[*].udpApp.maxProcDelay = 1e-3
-#Simulation.veh[*].udpApp.maxProcDelay = 1e-3
+Simulation.rsu[*].udpApp.maxProcDelay = 0
+Simulation.veh[*].udpApp.maxProcDelay = 0
 
 
 ########### UDP Settings      ###############
@@ -58,13 +63,12 @@ Simulation.mgmt.cmdenv-log-level = info   # = info
 **.wlan*.mgmt.typename = "Ieee80211MgmtAdhoc"
 **.wlan*.agent.typename = ""
 **.wlan*.opMode = "p"
-#**.wlan*.bitrate = 6Mbps
 
 **.wlan*.mac.typename = "Ieee80211Mac"
-**.wlan*.mac.*.rateSelection.*Bitrate = 3Mbps
+**.wlan*.mac.*.rateSelection.*Bitrate = 6Mbps
 **.wlan*.mac.hcf.maxQueueSize = 10
-**.wlan*.mac.cwMin = 15
-**.wlan*.mac.cwMax = 1023
+**.wlan*.mac.**.cwMin = 15
+**.wlan*.mac.**.cwMax = 1023
 **.wlan*.mac.dcf.recoveryProcedure.shortRetryLimit = 7
 **.wlan*.mac.dcf.recoveryProcedure.longRetryLimit = 7
 


### PR DESCRIPTION
## Type of this PR 

- [ ] Bug fix
- [x] Enhancement

## Description

- omnetpp.ini copied from MOSAIC's scenario Tiergarten
- revised omnetpp.ini:
  - no mobility section
  - log prefix extended by unit for simulation time
  - mac/phy layer settings revised

## Issue(s) related to this PR

 * internal issue 381
 
 
## Affected parts of the online documentation

none
